### PR TITLE
Feat/refactor plots to interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.4.0]
+
+### Changed
+- Refactored charts/app to use Altair for improved interactivity compared to Matplotlib static plots.
+
 ## [0.3.0]
 
 ### Added

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,9 @@ dependencies:
   - pandas=2.2.3
   - matplotlib=3.10.1
   - seaborn=0.13.2
+  - altair
+  - shinywidgets
+  - anywidget
   - jupyterlab
   - shiny
   - python-dotenv=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 shiny==1.5.1
+shinywidgets
 pandas==2.2.3
 matplotlib==3.10.1
+altair
+anywidget
 chatlas
 python-dotenv==1.0.0
 tabulate==0.8.10

--- a/src/app.py
+++ b/src/app.py
@@ -16,16 +16,17 @@ except ModuleNotFoundError:
 from shiny import reactive
 from shiny.express import input, render, ui
 from shiny.ui import page_navbar
+from shinywidgets import reactive_read, render_altair
 
 from charts import (
     ai_chart_engine_efficiency_scatter,
     ai_chart_fuel_avg_price,
     ai_chart_fuel_group_efficiency,
-    chart_brand_avg_price,
-    chart_engine_efficiency_scatter,
-    chart_fuel_avg_price,
-    chart_fuel_group_efficiency,
-    chart_hp_price_scatter,
+    chart_brand_avg_price_interactive,
+    chart_engine_efficiency_scatter_interactive,
+    chart_fuel_avg_price_interactive,
+    chart_fuel_group_efficiency_interactive,
+    chart_hp_price_scatter_interactive,
 )
 from data_processing import (
     as_selection as _as_selection,
@@ -260,20 +261,60 @@ with ui.nav_panel("EDA"):
             ui.input_action_button("reset_btn", "Reset Filters")
 
         @reactive.calc
-        def filtered_df():
+        def brand_chart_selection():
+            try:
+                selection = reactive_read(plot_brand_price.widget.selections, "brand_pick")
+            except Exception:
+                return []
+
+            if selection is None or selection.value is None:
+                return []
+
+            return [item["Brand"] for item in selection.value if "Brand" in item]
+
+        @reactive.calc
+        def fuel_chart_selection():
+            try:
+                selection = reactive_read(fuel_eff_plot.widget.selections, "fuel_pick")
+            except Exception:
+                return []
+
+            if selection is None or selection.value is None:
+                return []
+
+            return [item["Fuel_Type"] for item in selection.value if "Fuel_Type" in item]
+
+        @reactive.calc
+        def sidebar_filtered_df():
+            selected_brands = _as_selection(input.input_brand())
+
             return filter_dataframe(
                 data,
-                brands=_as_selection(input.input_brand()),
+                brands=selected_brands,
                 body_types=_as_selection(input.input_body_type()),
                 fuel_types=_as_selection(input.input_fuel_type()),
                 price_range=input.input_price_range(),
             )
 
         @reactive.calc
+        def filtered_df():
+            clicked_brands = brand_chart_selection()
+            clicked_fuels = fuel_chart_selection()
+
+            df = sidebar_filtered_df()
+            if clicked_brands:
+                df = df[df["Brand"].isin(clicked_brands)]
+            if clicked_fuels:
+                df = df[df["Fuel_Type"].isin(clicked_fuels)]
+            return df
+
+        @reactive.calc
         def filter_state_values():
-            brand_label = _selection_label(input.input_brand(), brand_choices)
+            selected_brands = brand_chart_selection() or _as_selection(input.input_brand())
+            brand_label = _selection_label(selected_brands, brand_choices)
             body_type_label = _selection_label(input.input_body_type(), body_type_choices)
-            fuel_type_label = _selection_label(input.input_fuel_type(), fuel_type_choices)
+            selected_fuels = fuel_chart_selection() or _as_selection(input.input_fuel_type())
+            fuel_type_label = _selection_label(selected_fuels, fuel_type_choices)
             price_low, price_high = input.input_price_range()
             currency = input.input_currency()
             rate = CURRENCY_RATES[currency]
@@ -366,10 +407,16 @@ with ui.nav_panel("EDA"):
             with ui.card():
                 ui.card_header("Average Price by Fuel Type")
 
-                @render.plot
+                ui.p(
+                    "Click bars to filter the EDA view by fuel type. Click again to clear.",
+                    class_="text-muted",
+                    style="font-size:0.85rem;",
+                )
+
+                @render_altair
                 def fuel_eff_plot():
-                    return chart_fuel_avg_price(
-                        filtered_df(),
+                    return chart_fuel_avg_price_interactive(
+                        sidebar_filtered_df(),
                         currency_sym=CURRENCY_SYMBOLS[input.input_currency()],
                         currency_rate=CURRENCY_RATES[input.input_currency()],
                     )
@@ -377,10 +424,16 @@ with ui.nav_panel("EDA"):
             with ui.card():
                 ui.card_header("Average Price by Brand")
 
-                @render.plot
+                ui.p(
+                    "Click bars to filter the EDA view by brand. Clear the selection by clicking the active bar again or clicking empty space.",
+                    class_="text-muted",
+                    style="font-size:0.85rem;",
+                )
+
+                @render_altair
                 def plot_brand_price():
-                    return chart_brand_avg_price(
-                        filtered_df(),
+                    return chart_brand_avg_price_interactive(
+                        sidebar_filtered_df(),
                         currency_sym=CURRENCY_SYMBOLS[input.input_currency()],
                         currency_rate=CURRENCY_RATES[input.input_currency()],
                     )
@@ -389,24 +442,36 @@ with ui.nav_panel("EDA"):
             with ui.card():
                 ui.card_header("Engine Size vs. Performance Efficiency")
 
-                @render.plot
+                ui.p(
+                    "Hover for details. Click the legend to highlight by fuel type.",
+                    class_="text-muted",
+                    style="font-size:0.85rem;",
+                )
+
+                @render_altair
                 def scatter_engine_efficiency():
-                    return chart_engine_efficiency_scatter(filtered_df())
+                    return chart_engine_efficiency_scatter_interactive(filtered_df())
 
             with ui.card():
                 ui.card_header("Average Performance Efficiency by Fuel Type")
 
-                @render.plot
+                @render_altair
                 def bar_fuel_efficiency():
-                    return chart_fuel_group_efficiency(filtered_df())
+                    return chart_fuel_group_efficiency_interactive(filtered_df())
 
         with ui.layout_columns(col_widths=(6, 6), gap="1rem", equal_height=True):
             with ui.card():
                 ui.card_header("Horsepower vs Price")
 
-                @render.plot
+                ui.p(
+                    "Hover for details. Click the legend to highlight by fuel type.",
+                    class_="text-muted",
+                    style="font-size:0.85rem;",
+                )
+
+                @render_altair
                 def plot_hp_price():
-                    return chart_hp_price_scatter(
+                    return chart_hp_price_scatter_interactive(
                         filtered_df(),
                         currency_sym=CURRENCY_SYMBOLS[input.input_currency()],
                         currency_rate=CURRENCY_RATES[input.input_currency()],

--- a/src/charts.py
+++ b/src/charts.py
@@ -12,6 +12,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import matplotlib.pyplot as plt
+import altair as alt
 import pandas as pd
 
 from data_processing import (
@@ -45,6 +46,16 @@ def _add_fuel_group(df: pd.DataFrame) -> pd.DataFrame:
         lambda x: "Hybrid" if x == "Hybrid" else "Standard Fuel"
     )
     return df
+
+
+def _empty_altair_fig(message: str = "No data for selected filters.") -> alt.Chart:
+    """Return a blank Altair chart with a centred message."""
+    return (
+        alt.Chart(pd.DataFrame({"message": [message]}))
+        .mark_text(align="center", baseline="middle", fontSize=14, color="#4b5563")
+        .encode(text="message:N")
+        .properties(width=FIG_WIDTH * 80, height=FIG_HEIGHT * 80)
+    )
 
 
 # ════════════════════════════════════════════════════════════════
@@ -118,6 +129,53 @@ def chart_brand_avg_price(
     ax.yaxis.set_major_formatter(make_currency_formatter(currency_sym))
     ax.grid(False)
     return fig
+
+
+def chart_brand_avg_price_interactive(
+    df: pd.DataFrame, currency_sym: str = "$", currency_rate: float = 1.0
+) -> alt.Chart:
+    """Interactive bar chart of average Price_USD by Brand for the EDA tab."""
+    if df.empty:
+        return alt.Chart(pd.DataFrame({"message": ["No data for selected filters."]})).mark_text(
+            align="center",
+            baseline="middle",
+            fontSize=14,
+            color="#4b5563",
+        ).encode(text="message:N").properties(width=FIG_WIDTH * 80, height=FIG_HEIGHT * 80)
+
+    agg = (
+        df.groupby("Brand", as_index=False)["Price_USD"]
+        .mean()
+        .sort_values("Price_USD", ascending=False)
+    )
+    agg["Price_display"] = agg["Price_USD"] * currency_rate
+
+    brand_pick = alt.selection_point(name="brand_pick", fields=["Brand"], empty=True)
+
+    return (
+        alt.Chart(agg)
+        .mark_bar(cornerRadiusTopLeft=6, cornerRadiusTopRight=6)
+        .encode(
+            x=alt.X("Brand:N", sort=None, title="Brand", axis=alt.Axis(labelAngle=-35)),
+            y=alt.Y(
+                "Price_display:Q",
+                title=f"Average Price ({currency_sym})",
+                axis=alt.Axis(format=",.0f"),
+            ),
+            color=alt.condition(
+                brand_pick,
+                alt.value("#3b82f6"),
+                alt.value("#bfd7ea"),
+            ),
+            tooltip=[
+                alt.Tooltip("Brand:N", title="Brand"),
+                alt.Tooltip("Price_display:Q", title=f"Average Price ({currency_sym})", format=",.0f"),
+            ],
+        )
+        .add_params(brand_pick)
+        .properties(width="container", height=320)
+        .configure_view(stroke=None)
+    )
 
 
 def chart_engine_efficiency_scatter(df: pd.DataFrame) -> plt.Figure:
@@ -234,6 +292,155 @@ def chart_hp_price_scatter(
     ax.grid(False)
     ax.yaxis.set_major_formatter(make_currency_formatter(currency_sym))
     return fig
+
+
+# ════════════════════════════════════════════════════════════════
+# EDA Interactive Charts  (Altair — tooltips + click-to-filter)
+# ════════════════════════════════════════════════════════════════
+
+def chart_fuel_avg_price_interactive(
+    df: pd.DataFrame, currency_sym: str = "$", currency_rate: float = 1.0
+) -> alt.Chart:
+    """Interactive bar chart — avg Price_USD by Fuel_Type (EDA tab). Click bar to filter."""
+    agg = df.groupby("Fuel_Type", as_index=False)["Price_USD"].mean()
+    agg["Price_display"] = agg["Price_USD"] * currency_rate
+
+    if agg.empty:
+        return _empty_altair_fig()
+
+    fuel_pick = alt.selection_point(name="fuel_pick", fields=["Fuel_Type"], empty=True)
+
+    return (
+        alt.Chart(agg)
+        .mark_bar(cornerRadiusTopLeft=6, cornerRadiusTopRight=6)
+        .encode(
+            x=alt.X("Fuel_Type:N", title="Fuel Type"),
+            y=alt.Y(
+                "Price_display:Q",
+                title=f"Average Price ({currency_sym})",
+                axis=alt.Axis(format=",.0f"),
+            ),
+            color=alt.condition(
+                fuel_pick,
+                alt.value("#3b82f6"),
+                alt.value("#bfd7ea"),
+            ),
+            tooltip=[
+                alt.Tooltip("Fuel_Type:N", title="Fuel Type"),
+                alt.Tooltip("Price_display:Q", title=f"Avg Price ({currency_sym})", format=",.0f"),
+            ],
+        )
+        .add_params(fuel_pick)
+        .properties(width="container", height=320)
+        .configure_view(stroke=None)
+    )
+
+
+def chart_engine_efficiency_scatter_interactive(df: pd.DataFrame) -> alt.Chart:
+    """Scatter — Engine_CC vs Efficiency_Score, coloured by Fuel_Type (EDA tab). Hover + legend click."""
+    if df.empty:
+        return _empty_altair_fig()
+
+    fuel_sel = alt.selection_point(name="eng_fuel_sel", fields=["Fuel_Type"], bind="legend")
+
+    return (
+        alt.Chart(df)
+        .mark_circle(size=60, opacity=0.7)
+        .encode(
+            x=alt.X("Engine_CC:Q", title="Engine Size (CC)"),
+            y=alt.Y("Efficiency_Score:Q", title="Performance Efficiency"),
+            color=alt.Color("Fuel_Type:N", title="Fuel Type"),
+            opacity=alt.condition(fuel_sel, alt.value(0.8), alt.value(0.15)),
+            tooltip=[
+                alt.Tooltip("Brand:N", title="Brand"),
+                alt.Tooltip("Fuel_Type:N", title="Fuel Type"),
+                alt.Tooltip("Engine_CC:Q", title="Engine CC", format=","),
+                alt.Tooltip("Efficiency_Score:Q", title="Efficiency", format=".2f"),
+                alt.Tooltip("Price_USD:Q", title="Price (USD)", format=",.0f"),
+            ],
+        )
+        .add_params(fuel_sel)
+        .properties(width="container", height=320)
+        .configure_view(stroke=None)
+    )
+
+
+def chart_fuel_group_efficiency_interactive(df: pd.DataFrame) -> alt.Chart:
+    """Bar chart — avg Efficiency_Score for Hybrid vs Standard Fuel (EDA tab). Hover tooltip."""
+    if df.empty:
+        return _empty_altair_fig()
+
+    df = _add_fuel_group(df)
+    agg = df.groupby("Fuel_Group", as_index=False)["Efficiency_Score"].mean()
+
+    order = ["Hybrid", "Standard Fuel"]
+    agg["Fuel_Group"] = pd.Categorical(agg["Fuel_Group"], categories=order, ordered=True)
+    agg = agg.sort_values("Fuel_Group")
+
+    return (
+        alt.Chart(agg)
+        .mark_bar(cornerRadiusTopLeft=6, cornerRadiusTopRight=6, width=80)
+        .encode(
+            x=alt.X("Fuel_Group:N", title=None, sort=order),
+            y=alt.Y(
+                "Efficiency_Score:Q",
+                title="Avg Performance Efficiency",
+                scale=alt.Scale(domain=[0, 1]),
+                axis=alt.Axis(format=".1f"),
+            ),
+            color=alt.Color(
+                "Fuel_Group:N",
+                scale=alt.Scale(
+                    domain=["Hybrid", "Standard Fuel"],
+                    range=["#5f0f40", "#ff7f51"],
+                ),
+                legend=None,
+            ),
+            tooltip=[
+                alt.Tooltip("Fuel_Group:N", title="Group"),
+                alt.Tooltip("Efficiency_Score:Q", title="Avg Efficiency", format=".2f"),
+            ],
+        )
+        .properties(width="container", height=320)
+        .configure_view(stroke=None)
+    )
+
+
+def chart_hp_price_scatter_interactive(
+    df: pd.DataFrame, currency_sym: str = "$", currency_rate: float = 1.0
+) -> alt.Chart:
+    """Scatter — Horsepower vs Price_USD, coloured by Fuel_Type (EDA tab). Hover + legend click."""
+    if df.empty:
+        return _empty_altair_fig()
+
+    df = df.dropna(subset=["Horsepower", "Price_USD"]).copy()
+    df["Price_display"] = df["Price_USD"] * currency_rate
+
+    fuel_sel = alt.selection_point(name="hp_fuel_sel", fields=["Fuel_Type"], bind="legend")
+
+    return (
+        alt.Chart(df)
+        .mark_circle(size=60, opacity=0.7)
+        .encode(
+            x=alt.X("Horsepower:Q", title="Horsepower"),
+            y=alt.Y(
+                "Price_display:Q",
+                title=f"Price ({currency_sym})",
+                axis=alt.Axis(format=",.0f"),
+            ),
+            color=alt.Color("Fuel_Type:N", title="Fuel Type"),
+            opacity=alt.condition(fuel_sel, alt.value(0.8), alt.value(0.15)),
+            tooltip=[
+                alt.Tooltip("Brand:N", title="Brand"),
+                alt.Tooltip("Fuel_Type:N", title="Fuel Type"),
+                alt.Tooltip("Horsepower:Q", title="Horsepower", format=","),
+                alt.Tooltip("Price_display:Q", title=f"Price ({currency_sym})", format=",.0f"),
+            ],
+        )
+        .add_params(fuel_sel)
+        .properties(width="container", height=320)
+        .configure_view(stroke=None)
+    )
 
 
 # ════════════════════════════════════════════════════════════════

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -6,6 +6,7 @@ Run from project root: pytest tests/test_charts.py -v
 import sys
 from pathlib import Path
 
+import altair as alt
 import matplotlib.pyplot as plt
 import pandas as pd
 import pytest
@@ -15,10 +16,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from charts import (
     chart_fuel_avg_price,
+    chart_fuel_avg_price_interactive,
     chart_brand_avg_price,
+    chart_brand_avg_price_interactive,
     chart_engine_efficiency_scatter,
+    chart_engine_efficiency_scatter_interactive,
     chart_fuel_group_efficiency,
+    chart_fuel_group_efficiency_interactive,
     chart_hp_price_scatter,
+    chart_hp_price_scatter_interactive,
     ai_chart_engine_efficiency_scatter,
     ai_chart_fuel_group_efficiency,
     ai_chart_fuel_avg_price,
@@ -28,6 +34,11 @@ from charts import (
 def _is_valid_figure(fig):
     """Return True if fig is a matplotlib Figure with at least one axes."""
     return isinstance(fig, plt.Figure) and len(fig.axes) >= 1
+
+
+def _is_valid_altair_chart(chart):
+    """Return True if chart is an Altair chart object."""
+    return isinstance(chart, alt.TopLevelMixin)
 
 
 # Fixtures: minimal DataFrames for EDA and AI charts 
@@ -92,6 +103,16 @@ def test_chart_brand_avg_price_empty_returns_figure(df_empty):
     assert _is_valid_figure(fig)
 
 
+def test_chart_brand_avg_price_interactive_returns_chart(df_eda):
+    chart = chart_brand_avg_price_interactive(df_eda)
+    assert _is_valid_altair_chart(chart)
+
+
+def test_chart_brand_avg_price_interactive_empty_returns_chart(df_empty):
+    chart = chart_brand_avg_price_interactive(df_empty)
+    assert _is_valid_altair_chart(chart)
+
+
 def test_chart_engine_efficiency_scatter_returns_figure(df_eda):
     fig = chart_engine_efficiency_scatter(df_eda)
     assert _is_valid_figure(fig)
@@ -125,6 +146,46 @@ def test_chart_hp_price_scatter_empty_returns_figure(df_empty):
 def test_chart_hp_price_scatter_currency_params(df_eda):
     fig = chart_hp_price_scatter(df_eda, currency_sym="€", currency_rate=0.92)
     assert _is_valid_figure(fig)
+
+
+def test_chart_fuel_avg_price_interactive_returns_chart(df_eda):
+    chart = chart_fuel_avg_price_interactive(df_eda)
+    assert _is_valid_altair_chart(chart)
+
+
+def test_chart_fuel_avg_price_interactive_empty_returns_chart(df_empty):
+    chart = chart_fuel_avg_price_interactive(df_empty)
+    assert _is_valid_altair_chart(chart)
+
+
+def test_chart_engine_efficiency_scatter_interactive_returns_chart(df_eda):
+    chart = chart_engine_efficiency_scatter_interactive(df_eda)
+    assert _is_valid_altair_chart(chart)
+
+
+def test_chart_engine_efficiency_scatter_interactive_empty_returns_chart(df_empty):
+    chart = chart_engine_efficiency_scatter_interactive(df_empty)
+    assert _is_valid_altair_chart(chart)
+
+
+def test_chart_fuel_group_efficiency_interactive_returns_chart(df_eda):
+    chart = chart_fuel_group_efficiency_interactive(df_eda)
+    assert _is_valid_altair_chart(chart)
+
+
+def test_chart_fuel_group_efficiency_interactive_empty_returns_chart(df_empty):
+    chart = chart_fuel_group_efficiency_interactive(df_empty)
+    assert _is_valid_altair_chart(chart)
+
+
+def test_chart_hp_price_scatter_interactive_returns_chart(df_eda):
+    chart = chart_hp_price_scatter_interactive(df_eda)
+    assert _is_valid_altair_chart(chart)
+
+
+def test_chart_hp_price_scatter_interactive_empty_returns_chart(df_empty):
+    chart = chart_hp_price_scatter_interactive(df_empty)
+    assert _is_valid_altair_chart(chart)
 
 
 # AI chart smoke tests 


### PR DESCRIPTION
This PR refactors chart.py and app.py to switch over from matplotlib static charts to interactive Altair plots. I've only switched over the ones within the EDA tab umbrella as an initial test since we're going to remove/modify some plots on this tab later down the line (scatter plots). 

Features:
- Tooltips for all EDA plots
- Click to filter for bar charts
- All Altair features such as `save as .png`
