### PR TITLE
Add chart captions explaining efficiency score and scatter plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Multi select filtering support for dashboard controls.
 - Default dashboard view shows data filtered for relevant user story.
 - Filters are now shown as cards with clear labels and consistent styling.
+- Currency selector (USD / CAD / EUR) in EDA sidebar with approximate conversion; prices and value boxes in Overview and EDA charts use selected currency and symbol.
+- Modular structure: data logic, chart logic , app using Shiny `@render` / `@reactive`.
+- Project docs: `CONTRIBUTING.md` (module ownership, branch naming, PR rules, reviewer rotation) and `CODEOWNERS` for review assignments.
+- tests added for edge-case and correctness (empty DataFrame, nulls, type checks, filter correctness, `load_data`, `build_choices`, `build_defaults`, `filter_dataframe`, `compute_kpis`, `as_selection`, `selection_label`).
+- smoke tests ensuring all EDA and AI chart functions return valid matplotlib Figure objects.
 
 ### Changed
 - Improved dashboard UI/UX with a consistent theme and visual hierarchy.
@@ -14,11 +19,13 @@
 - Standardized chart sizing and layout across the dashboard.
 - Moved scatter plot legends outside of plots to improve readability.
 - Added value labels above bar charts for easier interpretation.
-- Improved price formatting using comma-separated USD values.
+- Improved price formatting using comma-separated USD values (and currency-aware formatting when CAD/EUR selected).
+- Overview “Dataset quick stats” made dynamic and currency-aware.
 
 ### Fixed
 - Inconsistent plot sizing between chart panels.
 - Redundant chart titles between card headers and plot titles.
+- Fixes for publishing and running the app on Posit Connect.
 
 ### Known Issues
 - Scatter plots currently use static matplotlib rendering and do not yet support hover tooltips.

--- a/src/app.py
+++ b/src/app.py
@@ -164,6 +164,12 @@ ui.head_content(
     .btn {
         border-radius: 10px;
     }
+
+    .card p {
+        font-size: 0.9rem;
+        color: #6b7280;
+        margin-top: 0.5rem;
+    }
     """)
 )
 
@@ -392,6 +398,12 @@ with ui.nav_panel("EDA"):
                 @render.plot
                 def scatter_engine_efficiency():
                     return chart_engine_efficiency_scatter(filtered_df())
+                
+                ui.p(
+                    "Note: Each point represents a vehicle. The chart compares engine size "
+                    "with the calculated performance efficiency score. Colors represent "
+                    "different fuel types."
+                )
 
             with ui.card():
                 ui.card_header("Average Performance Efficiency by Fuel Type")
@@ -399,6 +411,12 @@ with ui.nav_panel("EDA"):
                 @render.plot
                 def bar_fuel_efficiency():
                     return chart_fuel_group_efficiency(filtered_df())
+                
+                ui.p(
+                    "Note: Efficiency score is a normalized metric summarizing how "
+                    "effectively engine performance translates into fuel efficiency. "
+                    "Higher values indicate better efficiency."
+                 )
 
         with ui.layout_columns(col_widths=(6, 6), gap="1rem", equal_height=True):
             with ui.card():


### PR DESCRIPTION
#83 

### Changes
- Added caption to **Engine Size vs Performance Efficiency** scatter plot.
- Added caption explaining the **Efficiency Score** metric in the fuel efficiency chart.
- Added caption to **Horsepower vs Price** scatter plot.

### Related Issue
Closes: M4 Feedback Prioritization – "Add captions or metric explanations to charts where interpretation is unclear"