### PR TITLE
playwright done

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
 __pycache__/
+.DS_Store
+data/.DS_Store
+*.DS_Store*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Added
 - Chart captions explaining Efficiency Score and scatter plot interpretation (addressing feedback #73 via #84).
 - Example prompt suggestions in the Querychat interface with copyable span components (#76).
-- Playwright tests verifying core dashboard behaviors (#98).
+- Playwright tests verifying core dashboard behaviors (#108).
 - Unit tests for refactored chart logic functions (#98).
 - Parquet dataset stored in `data/processed/` for improved data loading architecture (#92).
 - DuckDB + ibis integration enabling lazy filtering before data enters memory (#92).

--- a/README.md
+++ b/README.md
@@ -42,6 +42,39 @@ conda activate car_price_analysis_env
 shiny run --reload src/app.py
 ```
 
+## Running Tests
+
+### One-command (all tests — pytest unit + Playwright e2e)
+```bash
+pytest tests/ -v
+```
+
+### Unit tests only (no browser required)
+```bash
+pytest tests/test_data_processing.py tests/test_charts.py -v
+```
+
+### Playwright end-to-end tests only
+Requires the Chromium browser to be installed once:
+```bash
+pip install pytest-playwright
+playwright install chromium
+```
+Then run:
+```bash
+pytest tests/test_playwright.py -v
+```
+
+### What each Playwright test covers
+
+| Test | Behavior verified | What breaks if it changes |
+|------|-------------------|--------------------------|
+| `test_eda_tab_loads_filter_state` | EDA tab renders the filter state card with Brand = "All" by default | App fails to load or reactive outputs stop rendering |
+| `test_vehicle_count_kpi_shows_positive_number` | Vehicle Count KPI displays a positive integer | Data loading or the `compute_kpis` aggregation is broken |
+| `test_currency_selector_updates_avg_price_label` | Switching to CAD updates the Avg Price KPI title to "CAD" | Currency reactive input is disconnected from the value box |
+| `test_reset_filters_restores_brand_to_all` | Reset Filters button clears a brand selection back to "All" | The reset effect stops firing or stops updating the selectize |
+| `test_fuel_filter_change_updates_vehicle_count` | Narrowing fuel type to Electric reduces the vehicle count | The fuel-type filter no longer drives `filtered_df` |
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines.

--- a/environment.yml
+++ b/environment.yml
@@ -20,9 +20,9 @@ dependencies:
   - pyarrow
   - tabulate=0.8.10
   - pytest
-  - playwright
   - pip
   - pip:
       - chatlas
       - querychat==0.5.1
       - vl-convert-python
+      - pytest-playwright

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - pyarrow
   - tabulate=0.8.10
   - pytest
+  - playwright
   - pip
   - pip:
       - chatlas

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ querychat==0.5.1
 duckdb
 ibis-framework[duckdb]
 pyarrow
+pytest-playwright

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+"""
+Shared fixtures for Playwright end-to-end tests.
+
+Starts a local Shiny app server once per test session so all Playwright tests
+can connect to the same running instance.
+"""
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+APP_PORT = 8765
+APP_URL = f"http://127.0.0.1:{APP_PORT}"
+
+
+@pytest.fixture(scope="session")
+def app_server():
+    """Launch the Shiny app on a fixed port and shut it down after the session."""
+    proc = subprocess.Popen(
+        ["python", "-m", "shiny", "run", "--port", str(APP_PORT), "src/app.py"],
+        cwd=PROJECT_ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Allow enough time for the app to load data and bind the port
+    time.sleep(30)
+    yield APP_URL
+    proc.terminate()
+    proc.wait(timeout=10)

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -112,11 +112,20 @@ def test_fuel_filter_change_updates_vehicle_count(page: Page, app_server: str) -
         "Shiny.setInputValue('input_fuel_type', ['Electric'], {priority: 'event'})"
     )
 
-    # Wait for the count to update to a different (smaller) number
-    expect(count_box).not_to_contain_text(str(default_count), timeout=TIMEOUT)
+    # Wait for the count to stabilize at a value different from the default.
+    # Using not_to_contain_text(str(default_count)) is unreliable when the
+    # default count is a substring of the filtered count (e.g. "68" inside
+    # "168"), so we poll until the extracted integer changes instead.
+    def get_count() -> int:
+        return int("".join(ch for ch in count_box.inner_text() if ch.isdigit()))
+
+    page.wait_for_function(
+        f"() => document.querySelector('#value_box_count').innerText.replace(/\\D/g, '') !== '{default_count}'",
+        timeout=TIMEOUT,
+    )
     expect(count_box).to_contain_text(re.compile(r"\d+"), timeout=TIMEOUT)
 
-    filtered_count = int("".join(ch for ch in count_box.inner_text() if ch.isdigit()))
+    filtered_count = get_count()
 
     assert filtered_count < default_count, (
         f"Expected filtered count ({filtered_count}) < default ({default_count}) "

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -1,0 +1,124 @@
+"""
+Playwright end-to-end tests for the Car Price Analysis dashboard.
+
+Run from project root with a single command:
+    pytest tests/test_playwright.py -v
+
+Requires:
+    pip install pytest-playwright
+    playwright install chromium
+"""
+
+import re
+
+import pytest
+from playwright.sync_api import Page, expect
+
+# Milliseconds to wait for reactive Shiny outputs to settle
+TIMEOUT = 30_000
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def go_to_eda(page: Page, base_url: str) -> None:
+    """Navigate to the app and open the EDA tab."""
+    page.goto(base_url)
+    page.get_by_role("tab", name="EDA").click()
+    # Wait until the reactive filter-state card has rendered
+    expect(page.locator("#current_filter_state")).to_be_visible(timeout=TIMEOUT)
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_eda_tab_loads_filter_state(page: Page, app_server: str) -> None:
+    """Verifies the EDA tab renders the Current filter state card with Brand
+    defaulting to 'All', confirming the dashboard loads and reactive outputs
+    are working."""
+    go_to_eda(page, app_server)
+
+    filter_card = page.locator("#current_filter_state")
+    expect(filter_card).to_be_visible(timeout=TIMEOUT)
+    # Brand pill should read "All" when no brand is selected
+    expect(filter_card).to_contain_text("All", timeout=TIMEOUT)
+
+
+def test_vehicle_count_kpi_shows_positive_number(page: Page, app_server: str) -> None:
+    """Verifies the Vehicle Count KPI in the EDA tab displays a positive integer,
+    confirming that data is loaded and the summary aggregation is working."""
+    go_to_eda(page, app_server)
+
+    count_box = page.locator("#value_box_count")
+    # Wait until the reactive value has rendered (shell appears before content)
+    expect(count_box).to_contain_text(re.compile(r"\d+"), timeout=TIMEOUT)
+
+    count_text = count_box.inner_text()
+    digits = "".join(ch for ch in count_text if ch.isdigit())
+    assert int(digits) > 0, f"Vehicle count should be > 0, got: {count_text!r}"
+
+
+def test_currency_selector_updates_avg_price_label(page: Page, app_server: str) -> None:
+    """Verifies that switching the currency radio button to CAD updates the
+    Average Price KPI to display 'CAD', confirming currency conversion is
+    reactive and wired to the display."""
+    go_to_eda(page, app_server)
+
+    # Default is USD — the KPI title should include "USD"
+    avg_price_box = page.locator("#value_box_avg_price")
+    expect(avg_price_box).to_contain_text("USD", timeout=TIMEOUT)
+
+    # Switch to CAD
+    page.locator("input[type='radio'][value='CAD']").click()
+
+    # KPI title should now include "CAD"
+    expect(avg_price_box).to_contain_text("CAD", timeout=TIMEOUT)
+
+
+def test_reset_filters_restores_brand_to_all(page: Page, app_server: str) -> None:
+    """Verifies that clicking Reset Filters clears a brand selection and returns
+    the Brand filter-state pill to 'All', confirming the reset button correctly
+    restores sidebar defaults."""
+    go_to_eda(page, app_server)
+
+    # Programmatically set the brand input to a single brand via the Shiny JS API
+    page.evaluate("Shiny.setInputValue('input_brand', ['Toyota'], {priority: 'event'})")
+
+    # Wait for the filter state to reflect the selection (Brand no longer "All")
+    filter_card = page.locator("#current_filter_state")
+    expect(filter_card).to_contain_text("Toyota", timeout=TIMEOUT)
+
+    # Click Reset Filters
+    page.locator("#reset_btn").click()
+
+    # Brand pill should return to "All"
+    expect(filter_card).to_contain_text("All", timeout=TIMEOUT)
+
+
+def test_fuel_filter_change_updates_vehicle_count(page: Page, app_server: str) -> None:
+    """Verifies that programmatically clearing the fuel-type filter to a single
+    value reduces the Vehicle Count KPI, confirming the fuel-type filter drives
+    the dataset visible to the dashboard charts."""
+    go_to_eda(page, app_server)
+
+    count_box = page.locator("#value_box_count")
+    # Wait until the reactive value has rendered
+    expect(count_box).to_contain_text(re.compile(r"\d+"), timeout=TIMEOUT)
+
+    # Record the default vehicle count
+    default_count = int("".join(ch for ch in count_box.inner_text() if ch.isdigit()))
+
+    # Narrow the fuel type to only "Electric"
+    page.evaluate(
+        "Shiny.setInputValue('input_fuel_type', ['Electric'], {priority: 'event'})"
+    )
+
+    # Wait for the count to update to a different (smaller) number
+    expect(count_box).not_to_contain_text(str(default_count), timeout=TIMEOUT)
+    expect(count_box).to_contain_text(re.compile(r"\d+"), timeout=TIMEOUT)
+
+    filtered_count = int("".join(ch for ch in count_box.inner_text() if ch.isdigit()))
+
+    assert filtered_count < default_count, (
+        f"Expected filtered count ({filtered_count}) < default ({default_count}) "
+        "after restricting to Electric only"
+    )


### PR DESCRIPTION
Adds a Playwright test suite (tests/test_playwright.py) that spins up the Shiny app locally and runs 5 end-to-end tests against it via a shared session fixture in conftest.py.

**Tests covered**
- EDA tab loads: confirms the dashboard renders and the reactive filter-state card is visible with Brand defaulting to "All"
- Vehicle Count KPI: asserts a positive integer is displayed, confirming data loads and aggregation works
- Currency selector: switches radio from USD → CAD and verifies the Average Price KPI label updates reactively
- Reset Filters: programmatically sets Brand to "Toyota", clicks Reset, and confirms the pill returns to "All"
- Fuel filter: narrows fuel type to "Electric" and asserts the Vehicle Count KPI drops below the default, confirming filter reactivity end-to-end

**Setup**
```

pip install pytest-playwright
playwright install chromium
pytest tests/test_playwright.py -v

```